### PR TITLE
Add release packaging to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - main
@@ -35,8 +37,17 @@ jobs:
             cp configs/BetterWho.json addons/counterstrikesharp/configs/plugins/BetterWho/BetterWho.json
           fi
 
+      - name: Package addon
+        run: zip -r BetterWho.zip addons/
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: BetterWho
           path: addons/
+
+      - name: Create GitHub Release
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: BetterWho.zip


### PR DESCRIPTION
## Summary
- add packaging step to compress the prepared addon contents
- publish the generated archive to a GitHub release when tag pushes occur
- allow the workflow to trigger on version tag pushes in addition to the main branch

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d0073c3e2c8322bdd94825698921aa