### PR TITLE
Adjust release zip step path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,9 @@ jobs:
           path: .
 
       - name: Zip release artifact
-        run: zip -r "BetterWho-${{ github.event.release.tag_name }}.zip" addons/
+        run: |
+          cd BetterWho
+          zip -r "../BetterWho-${{ github.event.release.tag_name }}.zip" addons/
 
       - name: Get release upload URL
         id: release_info


### PR DESCRIPTION
## Summary
- change the release workflow to zip the downloaded artifact from inside the extracted BetterWho directory
- ensure the archive is still written at the repository root for the upload step

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d011e662788322a949f3ea0865ff0d