### PR TITLE
Align release artifacts with tag name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,22 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.set_tag_name.outputs.tag_name }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Determine TAG_NAME
+        id: set_tag_name
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "TAG_NAME=${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
+            echo "tag_name=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "TAG_NAME=${{ github.ref_name }}" >> "$GITHUB_ENV"
+            echo "tag_name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
@@ -40,7 +53,7 @@ jobs:
           fi
 
       - name: Package addon
-        run: zip -r "BetterWho-${{ github.event.release.tag_name }}.zip" addons/
+        run: zip -r "BetterWho-${TAG_NAME}.zip" addons/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -52,7 +65,7 @@ jobs:
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
-          files: BetterWho.zip
+          files: BetterWho-${{ env.TAG_NAME }}.zip
 
   release:
     needs: build
@@ -60,6 +73,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
     steps:
+      - name: Set TAG_NAME
+        run: echo "TAG_NAME=${{ needs.build.outputs.tag_name }}" >> "$GITHUB_ENV"
+
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
@@ -69,7 +85,7 @@ jobs:
       - name: Zip release artifact
         run: |
           cd BetterWho
-          zip -r "../BetterWho-${{ github.event.release.tag_name }}.zip" -i counterstriksharp/
+          zip -r "../BetterWho-${TAG_NAME}.zip" -i counterstriksharp/
       - name: Get release upload URL
         id: release_info
         env:
@@ -87,6 +103,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.release_info.outputs.upload_url }}
-          asset_path: BetterWho-${{ github.event.release.tag_name }}.zip
-          asset_name: cs2-betterwho-${{ github.event.release.tag_name }}.zip
+          asset_path: BetterWho-${{ env.TAG_NAME }}.zip
+          asset_name: cs2-betterwho-${{ env.TAG_NAME }}.zip
           asset_content_type: application/zip


### PR DESCRIPTION
## Summary
- set a shared TAG_NAME value for builds triggered by tag pushes or release events
- package the addon zip and attach release assets using the resolved TAG_NAME
- reuse the computed TAG_NAME when re-uploading artifacts in the release job for consistent naming

## Testing
- Not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d01733b4b4832297b75e0bf070a2cf