### PR TITLE
Remove unsupported overwrite flag from release upload

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -70,7 +70,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ env.PACKAGE_ARCHIVE }}
-          overwrite: true
 
       - name: Document package layout
         if: always()


### PR DESCRIPTION
## Summary
- remove the unsupported `overwrite` input from the release asset upload step so the workflow only uses valid parameters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d028e131108322b169bd483f29224d