### PR TITLE
Format BetterWho command output with colored card

### DIFF
--- a/src/BetterWho/BetterWhoPlugin.cs
+++ b/src/BetterWho/BetterWhoPlugin.cs
@@ -61,10 +61,24 @@ public class BetterWhoPlugin : BasePlugin
                 ? string.Join(", ", permissions)
                 : "None";
 
-            var message =
-                $"{player.PlayerName} | {profileLink} | {ipAddress} | {permissionText}";
+            const string separatorColor = "\x07FFA500";
+            const string labelColor = "\x07ADD8E6";
+            const string valueColor = "\x07FFFFFF";
 
-            command.ReplyToCommand(message);
+            var cardLines = new[]
+            {
+                $"{separatorColor}**************",
+                $"{labelColor}* Pseudo : {valueColor}{player.PlayerName}",
+                $"{labelColor}* Profile : {valueColor}{profileLink}",
+                $"{labelColor}* IP : {valueColor}{ipAddress}",
+                $"{labelColor}* Permissions : {valueColor}{permissionText}",
+                $"{separatorColor}**************"
+            };
+
+            foreach (var line in cardLines)
+            {
+                command.ReplyToCommand(line);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- replace the single-line BetterWho command output with a set of formatted card lines
- add CounterStrikeSharp color codes to the separator, labels, and values for readability
- send each colored line individually so players see their name, profile, IP, and permissions clearly

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d04461f0dc8322b33f8f698be44d2f