### PR TITLE
Format css_bwho output as multiline card without colors

### DIFF
--- a/src/BetterWho/BetterWhoPlugin.cs
+++ b/src/BetterWho/BetterWhoPlugin.cs
@@ -94,10 +94,24 @@ public class BetterWhoPlugin : BasePlugin
             ? string.Join(", ", permissions)
             : "None";
 
-        var message =
-            $"{targetPlayer.PlayerName} | {profileLink} | {ipAddress} | {permissionText}";
+        var playerName = string.IsNullOrWhiteSpace(targetPlayer.PlayerName)
+            ? "Unknown"
+            : targetPlayer.PlayerName;
 
-        command.ReplyToCommand(message);
+        var cardLines = new[]
+        {
+            "**********************",
+            $"* Pseudo : {playerName}",
+            $"* Profile : {profileLink}",
+            $"* Ip : {ipAddress}",
+            $"* Permissions : {permissionText}",
+            "**********************"
+        };
+
+        foreach (var line in cardLines)
+        {
+            command.ReplyToCommand(line);
+        }
     }
 
     private static bool PlayerMatchesArgument(CCSPlayerController player, string targetArg)


### PR DESCRIPTION
## Summary
- format the `css_bwho` command output as a multi-line card to match the requested layout
- include a fallback when the player name is missing while keeping the card uncolored

## Testing
- ⚠️ `dotnet build` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d043f5619c8322bc14ad8f25333a99